### PR TITLE
#6 Replace the using directive with explicit forward calls to base class

### DIFF
--- a/fmatvec/vector.h
+++ b/fmatvec/vector.h
@@ -280,7 +280,8 @@ namespace fmatvec {
        * */
       inline const Vector<Ref,AT> operator()(const Range<Var,Var> &I) const;
 
-      using Matrix<General,Ref,Ref,AT>::operator();
+      AT* operator()() { return Matrix<General, Ref, Ref, AT>::operator()(); }
+      const AT* operator()() const { return Matrix<General, Ref, Ref, AT>::operator()(); }
 
       /*! \brief Cast to std::vector<AT>.
        *


### PR DESCRIPTION
The MSVC compilers fail with the using directive with error C3306; though this is not a fmatvec error, it was decided to replace for all platforms.

@rolandzander  FYI