### PR TITLE
Fix MSVC x64 warnings C4267: conversion from 'size_t' to 'int'

### DIFF
--- a/fmatvec/ast.cc
+++ b/fmatvec/ast.cc
@@ -388,7 +388,7 @@ Symbol::Symbol(const boost::uuids::uuid& uuid_) : version(0), uuid(uuid_) {}
 string Symbol::getUUIDStr() const {
 #ifndef NDEBUG // FMATVEC_DEBUG_SYMBOLICEXPRESSION_UUID
   if(getenv("FMATVEC_DEBUG_SYMBOLICEXPRESSION_UUID")) {
-    auto res=mapUUIDInt.insert(make_pair(uuid, mapUUIDInt.size()+1));
+    auto res=mapUUIDInt.insert(make_pair(uuid, static_cast<int>(mapUUIDInt.size())+1));
     return "s"+to_string(res.first->second);
   }
   return to_string(uuid);

--- a/fmatvec/ast.cc
+++ b/fmatvec/ast.cc
@@ -183,7 +183,7 @@ ostream& operator<<(ostream& s, const SymbolicExpression& se) {
 // in the serialized output. This is quite usefull to write tests.
 // This envvar should NOT be set in normal program. It will generate wrong results if more than one
 // process in involved.
-static map<boost::uuids::uuid, int> mapUUIDInt;
+static map<boost::uuids::uuid, size_t> mapUUIDInt;
 #endif
 
 namespace {
@@ -388,7 +388,7 @@ Symbol::Symbol(const boost::uuids::uuid& uuid_) : version(0), uuid(uuid_) {}
 string Symbol::getUUIDStr() const {
 #ifndef NDEBUG // FMATVEC_DEBUG_SYMBOLICEXPRESSION_UUID
   if(getenv("FMATVEC_DEBUG_SYMBOLICEXPRESSION_UUID")) {
-    auto res=mapUUIDInt.insert(make_pair(uuid, static_cast<int>(mapUUIDInt.size())+1));
+    auto res=mapUUIDInt.insert(make_pair(uuid, mapUUIDInt.size()+1));
     return "s"+to_string(res.first->second);
   }
   return to_string(uuid);

--- a/fmatvec/fixed_var_general_matrix.h
+++ b/fmatvec/fixed_var_general_matrix.h
@@ -556,7 +556,7 @@ namespace fmatvec {
     }
 
   template <int M, class AT>
-    inline Matrix<General,Fixed<M>,Var,AT>::Matrix(const std::vector<std::vector<AT>> &m) : N(!m.empty()?m[0].size():0), ele(new AT[M*N]) {
+    inline Matrix<General,Fixed<M>,Var,AT>::Matrix(const std::vector<std::vector<AT>> &m) : N(!m.empty()? static_cast<int>(m[0].size()):0), ele(new AT[M*N]) {
       if(m.size() != M)
         throw std::runtime_error("The input has "+std::to_string(m.size())+" rows but "+std::to_string(M)+" rows are required.");
       for(int r=0; r<rows(); r++) {

--- a/fmatvec/general_matrix.h
+++ b/fmatvec/general_matrix.h
@@ -526,7 +526,7 @@ namespace fmatvec {
     }
 
   template <class AT>
-    inline Matrix<General,Ref,Ref,AT>::Matrix(const std::vector<std::vector<AT>> &m) : memory(m.size()*m[0].size()), ele((AT*)memory.get()), m(m.size()), n(m[0].size()), lda(m.size()) {
+    inline Matrix<General,Ref,Ref,AT>::Matrix(const std::vector<std::vector<AT>> &m) : memory(m.size()*m[0].size()), ele((AT*)memory.get()), m(static_cast<int>(m.size())), n(static_cast<int>(m[0].size())), lda(static_cast<int>(m.size())) {
       for(int r=0; r<rows(); r++) {
         if(static_cast<int>(m[r].size())!=cols())
           throw std::runtime_error("The rows of the input have different length.");

--- a/fmatvec/symmetric_matrix.h
+++ b/fmatvec/symmetric_matrix.h
@@ -486,7 +486,7 @@ namespace fmatvec {
     }
 
   template <class AT>
-    Matrix<Symmetric,Ref,Ref,AT>::Matrix(const std::vector<std::vector<AT>> &m) : Matrix<Symmetric,Ref,Ref,AT>(m.size()) {
+    Matrix<Symmetric,Ref,Ref,AT>::Matrix(const std::vector<std::vector<AT>> &m) : Matrix<Symmetric,Ref,Ref,AT>(static_cast<int>(m.size())) {
       for(int r=0; r<rows(); r++) {
         if(static_cast<int>(m[r].size())!=cols())
           throw std::runtime_error("The rows of the input have different length.");

--- a/fmatvec/var_fixed_general_matrix.h
+++ b/fmatvec/var_fixed_general_matrix.h
@@ -493,7 +493,7 @@ namespace fmatvec {
     }
 
   template <int N, class AT>
-    inline Matrix<General,Var,Fixed<N>,AT>::Matrix(const std::vector<std::vector<AT>> &m) : M(m.size()), ele(new AT[M*N]) {
+    inline Matrix<General,Var,Fixed<N>,AT>::Matrix(const std::vector<std::vector<AT>> &m) : M(static_cast<int>(m.size())), ele(new AT[M*N]) {
       if(m[0].size() != N)
         throw std::runtime_error("The input has "+std::to_string(m[0].size())+" columns but "+std::to_string(N)+" columns are required.");
       for(int r=0; r<rows(); r++) {

--- a/fmatvec/var_general_matrix.h
+++ b/fmatvec/var_general_matrix.h
@@ -549,7 +549,7 @@ namespace fmatvec {
     }
 
   template <class AT>
-    inline Matrix<General,Var,Var,AT>::Matrix(const std::vector<std::vector<AT>> &m) : M(m.size()), N(m[0].size()), ele(new AT[M*N]) {
+    inline Matrix<General,Var,Var,AT>::Matrix(const std::vector<std::vector<AT>> &m) : M(static_cast<int>(m.size())), N(static_cast<int>(m[0].size())), ele(new AT[M*N]) {
       for(int r=0; r<rows(); r++) {
         if(static_cast<int>(m[r].size())!=cols())
           throw std::runtime_error("The rows of the input have different length.");


### PR DESCRIPTION
Fixed several MSVC x64 warnings C4267: conversion from 'size_t' to 'int' - possible loss of data.
If PR is rejected, I'd suppress C4267 warnings in the MSVC build.