### PR TITLE
Fix msvc build continued

### DIFF
--- a/fmatvec/ast.cc
+++ b/fmatvec/ast.cc
@@ -283,6 +283,12 @@ SymbolicExpression parDer(const SymbolicExpression &dep, const IndependentVariab
   return dep->parDer(indep);
 }
 
+#ifdef _MSC_VER
+#ifndef SWIG
+const SymbolicExpression::ConstructSymbol SymbolicExpression::constructSymbol{}; // just used for tag dispatching
+#endif
+#endif
+
 // ***** IndependentVariable *****
 
 IndependentVariable::IndependentVariable() : SymbolicExpression(constructSymbol) {}

--- a/fmatvec/ast.cc
+++ b/fmatvec/ast.cc
@@ -401,7 +401,7 @@ string Symbol::getUUIDStr() const {
 
 map<Operation::CacheKey, weak_ptr<const Operation>, Operation::CacheKeyComp> Operation::cache;
 
-std::map<Operation::Operator, string> Operation::opMap {
+const std::map<Operation::Operator, string> Operation::opMap {
   { Plus,  "plus"},
   { Minus, "minus"},
   { Mult,  "mult"},

--- a/fmatvec/ast.h
+++ b/fmatvec/ast.h
@@ -344,7 +344,7 @@ class Operation : public Vertex, public std::enable_shared_from_this<Operation> 
     };
     static std::map<CacheKey, std::weak_ptr<const Operation>, CacheKeyComp> cache;
     mutable double cacheValue;
-    static std::map<Operator, std::string> opMap;
+    static const std::map<Operator, std::string> opMap;
 };
 
 double Operation::eval() const {

--- a/fmatvec/ast.h
+++ b/fmatvec/ast.h
@@ -316,9 +316,9 @@ class Operation : public Vertex, public std::enable_shared_from_this<Operation> 
   friend SymbolicExpression;
   friend SymbolicExpression fmatvec::subst(const SymbolicExpression &se, const IndependentVariable& a, const SymbolicExpression &b);
   friend boost::spirit::qi::rule<boost::spirit::istream_iterator, SymbolicExpression()>&
-    getBoostSpiritQiRule<SymbolicExpression>();
+    fmatvec::getBoostSpiritQiRule<SymbolicExpression>();
   friend boost::spirit::karma::rule<std::ostream_iterator<char>, SymbolicExpression()>&
-    getBoostSpiritKarmaRule<SymbolicExpression>();
+    fmatvec::getBoostSpiritKarmaRule<SymbolicExpression>();
   public:
 
     //! Defined operations.


### PR DESCRIPTION
* MSVC requires some location in the memory for `SymbolicExpression::constructSymbol` to compile.
* `Operation::opMap` initialized once and never modified. 