### PR TITLE
Fix msvc operator search

### DIFF
--- a/fmatvec/check/testast.cc
+++ b/fmatvec/check/testast.cc
@@ -1,10 +1,10 @@
 #include <cfenv>
 #include <cassert>
 #include <iostream>
-#include "fmatvec/linear_algebra_complex.h"
 #include "fmatvec/symbolic.h"
 #include "fmatvec/fmatvec.h"
 #include "fmatvec/stream_impl.h"
+#include "fmatvec/linear_algebra_complex.h"
 
 using namespace std;
 using namespace fmatvec;

--- a/fmatvec/check/testast.cc
+++ b/fmatvec/check/testast.cc
@@ -1,10 +1,10 @@
 #include <cfenv>
 #include <cassert>
 #include <iostream>
+#include "fmatvec/linear_algebra_complex.h"
 #include "fmatvec/symbolic.h"
 #include "fmatvec/fmatvec.h"
 #include "fmatvec/stream_impl.h"
-#include "fmatvec/linear_algebra_complex.h"
 
 using namespace std;
 using namespace fmatvec;

--- a/fmatvec/linear_algebra.h
+++ b/fmatvec/linear_algebra.h
@@ -22,8 +22,6 @@
 #ifndef linear_algebra_h
 #define linear_algebra_h
 
-#include <cmath>
-
 #include "square_matrix.h"
 #include "vector.h"
 #include "row_vector.h"

--- a/fmatvec/linear_algebra.h
+++ b/fmatvec/linear_algebra.h
@@ -39,6 +39,16 @@
 
 namespace fmatvec {
 
+  // template declaration for complex type defined in linear_algebra_complex.h
+  template<class T> std::complex<T> operator+(const std::complex<T> &x, int y);
+  template<class T> std::complex<T> operator-(const std::complex<T> &x, int y);
+  template<class T> std::complex<T> operator*(const std::complex<T> &x, int y);
+  template<class T> std::complex<T> operator/(const std::complex<T> &x, int y);
+  template<class T> std::complex<T> operator+(int x, const std::complex<T> &y);
+  template<class T> std::complex<T> operator-(int x, const std::complex<T> &y);
+  template<class T> std::complex<T> operator*(int x, const std::complex<T> &y);
+  template<class T> std::complex<T> operator/(int x, const std::complex<T> &y);
+
 /////////////////////////////////// vecvecadd //////////////////////////////
 
   // Vector-Vector


### PR DESCRIPTION
MSVC does not consider the operators from linear_algebra_complex.h if they are declared after usage, e.g. in Vector operator*(&x, &alpha) {}
The fix in testast.cc solves compile issues, but the responsibility to include in correct order remains at the library user. A permanent fix would be to add `#include "fmatvec/linear_algebra_complex.h"` to `linear_algebra.h` . I preferred the other solution, because I cannot decide, if this is a desired dependency between these two headers. Or if e.g. a third public header would be better, that includes all internal headers in the correct order.

BTW: The error message is pointing into the wrong direction...
```
fmatvec\linear_algebra.h(927): error C2678: binary '*': no operator found which takes a left-hand operand of type 'const AT' (or there is no acceptable conversion)
        with
        [
            AT=std::complex<double>
        ]
fmatvec\ast.h(139): note: could be 'fmatvec::SymbolicExpression fmatvec::operator *(int,const fmatvec::SymbolicExpression &)'
fmatvec\ast.h(135): note: or       'fmatvec::SymbolicExpression fmatvec::operator *(double,const fmatvec::SymbolicExpression &)'
fmatvec\linear_algebra.h(927): note: while trying to match the argument list '(const AT, const AT2)'
        with
        [
            AT=std::complex<double>
        ]
        and
        [
            AT2=int
        ]
fmatvec\check\testast.cc(33): note: see reference to function template instantiation 'fmatvec::Vector<fmatvec::Var,AT> fmatvec::operator *<fmatvec::Var,AT,int>(const fmatvec::Vector<fmatvec::Var,AT> &,const AT2 &)' being compiled
```
